### PR TITLE
All Changes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "viacool",
   "version": "0.1.0",
   "private": true,
-  "homepage": "app2/login",
+  "homepage": ".",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "viacool",
   "version": "0.1.0",
   "private": true,
-  "homepage": ".",
+  "homepage": "app2/login",
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",

--- a/src/App.js
+++ b/src/App.js
@@ -25,7 +25,7 @@ function App () {
   }
 
   return (
-    <BrowserRouter basename='/app2'>
+    <BrowserRouter>
       <Routes>
         <Route path='/login' element={<AuthLayout />}>
           <Route index element={<Login />} />

--- a/src/App.js
+++ b/src/App.js
@@ -20,12 +20,11 @@ function App () {
     if (!localStorage['authToken']) {
       return <Navigate to='/login' replace />
     }
-
     return children ? children : <Outlet />
   }
 
   return (
-    <BrowserRouter>
+    <BrowserRouter basename='/app2'>
       <Routes>
         <Route path='/login' element={<AuthLayout />}>
           <Route index element={<Login />} />
@@ -39,10 +38,12 @@ function App () {
             </ProtectedRoute>
           }
         >
+          <Route path='/' element={<Predict />} />
           <Route path='predict' element={<Predict />} />
           <Route path='settings' element={<Settings />} />
         </Route>
       </Routes>
+
       <ToastContainer />
     </BrowserRouter>
   )

--- a/src/components/common/Table.jsx
+++ b/src/components/common/Table.jsx
@@ -110,13 +110,19 @@ function Table({ cols, rows, selectable }) {
           </thead>
           <tbody>
             {rows
-              ?.filter((row) => row?.is_deleted === false)
+              ?.filter(
+                (row) =>
+                  row?.is_deleted === false &&
+                  row.name?.includes(selectedProduceType?.toLowerCase())
+              )
+
               ?.map((rowData, index) => {
                 const rowArray = [
                   rowData?.name,
                   rowData?.created_at,
                   selectedProduceType,
                 ];
+
                 return (
                   <tr
                     className="hover:bg-opacity-5 duration-150 bg-white hover:bg-primary-blue"

--- a/src/components/common/Table.jsx
+++ b/src/components/common/Table.jsx
@@ -48,7 +48,7 @@ const TableAction = ({ id, url, organizationId }) => {
         });
       })
       .catch((err) => {
-        toast.error(`Error : ${err?.response?.data?.message}, Please Retry`, {
+        toast.error(`Error : ${err?.response?.data?.detail}, Please Retry`, {
           position: "bottom-right",
           autoClose: 5000,
           hideProgressBar: false,

--- a/src/components/layout/Auth.jsx
+++ b/src/components/layout/Auth.jsx
@@ -1,11 +1,17 @@
-import React from 'react';
-import { Outlet } from 'react-router-dom';
-
+import React from "react";
+import { Outlet } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 function AuthLayout() {
+  const navigate = useNavigate();
+  React.useEffect(() => {
+    localStorage["authToken"] && navigate("/predict");
+  });
   return (
-    <div>
-      <Outlet />
-    </div>
+    !localStorage["authToken"] && (
+      <div>
+        <Outlet />
+      </div>
+    )
   );
 }
 

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,14 +1,31 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import { Outlet } from "react-router-dom";
 import Aside from "./Aside";
 import { UserContext } from "../../context/UserContext";
 import { userApi } from "../../apiServices/authApi";
 import { OrganizationContext } from "../../context/OrganizationContext";
+import { FormatContext } from "../../context/FormatContext";
+import { formatsApi } from "../../apiServices/formatsApi";
+import { getReports } from "../../apiServices/organizationApi";
 
 function Layout() {
   const { user, setUser } = useContext(UserContext);
   const { setOrganizationData } = useContext(OrganizationContext);
-  React.useEffect(() => {
+  function sortFunction(a, b) {
+    var dateA = new Date(a.created_at).getTime();
+    var dateB = new Date(b.created_at).getTime();
+    return dateA > dateB ? -1 : 1;
+  }
+  const { setFormatData, SetSelectedProduceType, format, setProduceTypes } =
+    useContext(FormatContext);
+  const {
+    organization,
+
+    setReport,
+    reports,
+  } = useContext(OrganizationContext);
+
+  useEffect(() => {
     const InitUserData = async () => {
       const res = await userApi();
       if (!res?.error) {
@@ -20,6 +37,40 @@ function Layout() {
     InitUserData();
   }, [!user]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    const InitData = async () => {
+      const res = await formatsApi();
+      if (!res?.error) {
+        setFormatData(res?.data);
+        const uniqueIds = [
+          ...new Set(organization?.ml_models?.map((d) => d?.produce_type_id)),
+        ];
+        const dataArray = [];
+        res?.data &&
+          Object?.keys(res?.data?.produce_types)?.map((d) =>
+            uniqueIds?.map(
+              (id) =>
+                id === res?.data?.produce_types[d] &&
+                dataArray?.push({
+                  value: res?.data?.produce_types[d],
+                  name: d,
+                })
+            )
+          );
+        setProduceTypes(dataArray);
+        SetSelectedProduceType(dataArray[0]?.value);
+      }
+      if (organization?.id) {
+        const reportz = await getReports(organization?.id);
+
+        if (!reports?.error) {
+          setReport(reportz?.sort(sortFunction));
+        }
+      }
+    };
+
+    InitData();
+  }, [!format, organization]); // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <div>
       <Aside />

--- a/src/views/login/Login.jsx
+++ b/src/views/login/Login.jsx
@@ -37,7 +37,7 @@ function Login() {
     if (response?.error) {
       setAuthCredentials({ ...authCredentials, loading: false });
       console.log("err", response?.error);
-      toast.error(`Error : ${response?.error?.message}`, {
+      toast.error(`Error : ${response?.error?.response?.data?.detail}`, {
         position: "bottom-right",
         autoClose: 5000,
         hideProgressBar: false,

--- a/src/views/login/Login.jsx
+++ b/src/views/login/Login.jsx
@@ -36,7 +36,8 @@ function Login() {
     const response = await loginApi(authCredentials);
     if (response?.error) {
       setAuthCredentials({ ...authCredentials, loading: false });
-      toast.error("Incorrect email or password", {
+      console.log("err", response?.error);
+      toast.error(`Error : ${response?.error?.message}`, {
         position: "bottom-right",
         autoClose: 5000,
         hideProgressBar: false,

--- a/src/views/predict/Predict.jsx
+++ b/src/views/predict/Predict.jsx
@@ -76,15 +76,18 @@ function Predict() {
       return;
     }
     setLoading(false);
-    toast.error(`Error Found: ${JSON.stringify(res?.error?.message)}`, {
-      position: "bottom-right",
-      autoClose: 5000,
-      hideProgressBar: false,
-      closeOnClick: true,
-      pauseOnHover: true,
-      draggable: true,
-      progress: undefined,
-    });
+    toast.error(
+      `Error Found: ${JSON.stringify(res?.error?.response?.data?.detail)}`,
+      {
+        position: "bottom-right",
+        autoClose: 5000,
+        hideProgressBar: false,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: undefined,
+      }
+    );
   };
 
   return (

--- a/src/views/predict/Predict.jsx
+++ b/src/views/predict/Predict.jsx
@@ -1,17 +1,16 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import Button from "../../components/common/Button";
 import FileUplaod from "../../components/common/FileUplaod";
 import SelectField from "../../components/common/SelectField";
 import Table from "../../components/common/Table";
 import Appbar from "../../components/layout/Appbar";
 import { FormatContext } from "../../context/FormatContext";
-
-import { formatsApi } from "../../apiServices/formatsApi";
 import { OrganizationContext } from "../../context/OrganizationContext";
 import { toast } from "react-toastify";
-import { getReports, UploadFileApi } from "../../apiServices/organizationApi";
+
 import Progress from "./Progress";
 import Modal from "../../components/common/Modal";
+import { UploadFileApi } from "../../apiServices/organizationApi";
 
 function Predict() {
   const [open, setOpen] = useState(false);
@@ -29,56 +28,26 @@ function Predict() {
     document.body.appendChild(element); // Required for this to work in FireFox
     element.click();
   };
-  const {
-    setFormatData,
-    SetSelectedProduceType,
-    format,
-    setProduceTypes,
-    produceTypes,
-    selectedProduceTypeId,
-  } = useContext(FormatContext);
-  const {
-    organization,
-    Files,
-    setReport,
-    reports,
-    UploadResponse,
-    setFilesResponse,
-  } = useContext(OrganizationContext);
+  const { produceTypes, selectedProduceTypeId } = useContext(FormatContext);
+  const { organization, Files, reports, UploadResponse, setFilesResponse } =
+    useContext(OrganizationContext);
 
-  React.useEffect(() => {
-    const InitData = async () => {
-      const res = await formatsApi();
-      if (!res?.error) {
-        setFormatData(res?.data);
-        const uniqueIds = [
-          ...new Set(organization?.ml_models?.map((d) => d?.produce_type_id)),
-        ];
-        const dataArray = [];
-        res?.data &&
-          Object?.keys(res?.data?.produce_types)?.map((d) =>
-            uniqueIds?.map(
-              (id) =>
-                id === res?.data?.produce_types[d] &&
-                dataArray?.push({
-                  value: res?.data?.produce_types[d],
-                  name: d,
-                })
-            )
+  const [inputRules, setRules] = useState(null);
+  useEffect(() => {
+    const data = organization?.ml_models?.filter(
+      (item) => item?.produce_type_id === selectedProduceTypeId
+    );
+    organization?.ml_models?.filter &&
+      setRules(
+        ...data?.map((ml_model, i) => {
+          return (
+            ml_model?.produce_type_id === selectedProduceTypeId &&
+            i === 0 &&
+            ml_model?.input_fields?.toString()?.split(",")
           );
-        setProduceTypes(dataArray);
-        SetSelectedProduceType(dataArray[0]?.value);
-      }
-      if (organization?.id) {
-        const reports = await getReports(organization?.id);
-        if (!reports?.error) {
-          setReport(reports);
-        }
-      }
-    };
-
-    InitData();
-  }, [!format, organization]); // eslint-disable-line react-hooks/exhaustive-deps
+        })
+      );
+  }, [organization, selectedProduceTypeId]);
 
   const [loading, setLoading] = useState(false);
   const handlePredict = async () => {
@@ -152,24 +121,13 @@ function Predict() {
           <div className="bg-neutral-375 rounded-[20px] px-4 py-7 text-md text-neutral-900 max-w-max">
             <p>Your files should include the following fields:</p>
             <br />
-            {organization?.ml_models?.map((ml_model, i) => {
-              return (
-                ml_model?.produce_type_id === selectedProduceTypeId &&
-                i === 0 && (
-                  <p className="px-2" key={i}>
-                    {ml_model?.input_fields
-                      ?.toString()
-                      ?.split(",")
-                      ?.map((inputField, index) => (
-                        <React.Fragment key={index}>
-                          {inputField}
-                          <br />
-                        </React.Fragment>
-                      ))}
-                  </p>
-                )
-              );
-            })}
+            <ul className="px-2">
+              {inputRules?.map((inputField, index) => (
+                <React.Fragment key={index}>
+                  <li> {inputField}</li>
+                </React.Fragment>
+              ))}
+            </ul>
           </div>
         </div>
       </div>


### PR DESCRIPTION
1) I uploaded more models for this user, but frontend doesn't pick up input fields for other models, than GRAPES

2) When I refresh Settings page Product list disappears, I need to click Predict, then go back to Settings, then it appears again.

3) When authorized user goes to https://app.via-cool.com/ he sees empty Layout, can you please make that they get redirected straight to /predict

4) List of Files on Predict page are ordered in ascending order, can you please make them sort in descending, because for user it is important to react latest files first

5) Also noticed when new user has more than one Produce types, and he select say Avocado, in Files section of Predict screen all file change Produce to selected type, that should not happen. Each report has produce_type_id to show there